### PR TITLE
fix unmatched async/await semantic

### DIFF
--- a/src/AsyncIterator.res
+++ b/src/AsyncIterator.res
@@ -23,5 +23,6 @@ let make = (~state: 'state, ~getNext: getNext<'state, 'value>): t<'value> => {
 }
 
 @module("./InjectedForLoop.js") external forAwaitOf: (t<'a>, 'a => unit) => unit = "forAwaitOf"
+@module("./InjectedForLoop.js") external forAwaitOfAsync: (t<'a>, 'a => promise<unit>) => promise<unit> = "forAwaitOfAsync"
 @module("./InjectedForLoop.js") @val external break: exn = "kBreak"
 @module("./InjectedForLoop.js") @val external continue: exn = "kContinue"

--- a/src/AsyncIterator.resi
+++ b/src/AsyncIterator.resi
@@ -2,5 +2,6 @@ type t<'value>
 type getNext<'state, 'value> = 'state => promise<option<'value>>
 let make: (~state: 'state, ~getNext: getNext<'state, 'value>) => t<'value>
 let forAwaitOf: (t<'a>, 'a => unit) => unit
+let forAwaitOfAsync: (t<'a>, 'a => promise<unit>) => promise<unit>
 let break: exn
 let continue: exn

--- a/src/InjectedForLoop.js
+++ b/src/InjectedForLoop.js
@@ -17,7 +17,7 @@ export const forOf = (iterator, fn) => {
   }
 };
 
-export const forAwaitOf = async (iterator, fn) => {
+export const forOfAsync = async (iterator, fn) => {
   for (let body of iterator) {
     try {
       await fn(body);
@@ -32,3 +32,36 @@ export const forAwaitOf = async (iterator, fn) => {
     }
   }
 };
+
+export const forAwaitOf = async (iterator, fn) => {
+  for await (let body of iterator) {
+    try {
+      fn(body);
+    } catch (exn) {
+      if (exn === kBreak) {
+        break;
+      }
+      if (exn === kContinue) {
+        continue;
+      }
+      throw exn;
+    }
+  }
+};
+
+export const forAwaitOfAsync = async (iterator, fn) => {
+  for await (let body of iterator) {
+    try {
+      await fn(body);
+    } catch (exn) {
+      if (exn === kBreak) {
+        break;
+      }
+      if (exn === kContinue) {
+        continue;
+      }
+      throw exn;
+    }
+  }
+};
+

--- a/src/Iterator.res
+++ b/src/Iterator.res
@@ -64,5 +64,7 @@ let make = (~state: 'state, ~getNext: getNext<'state, 'value>): t<'value> => {
 }
 
 @module("./InjectedForLoop.js") external forOf: (t<'a>, 'a => unit) => unit = "forOf"
+@module("./InjectedForLoop.js") external forOfAsync: (t<'a>, 'a => promise<unit>) => promise<unit> = "forOfAsync"
+
 @module("./InjectedForLoop.js") @val external break: exn = "kBreak"
 @module("./InjectedForLoop.js") @val external continue: exn = "kContinue"

--- a/src/Iterator.resi
+++ b/src/Iterator.resi
@@ -2,5 +2,6 @@ type t<'value>
 type getNext<'state, 'value> = 'state => option<'value>
 let make: (~state: 'state, ~getNext: getNext<'state, 'value>) => t<'value>
 let forOf: (t<'a>, 'a => unit) => unit
+let forOfAsync: (t<'a>, 'a => promise<unit>) => promise<unit>
 let break: exn
 let continue: exn


### PR DESCRIPTION
`Iterator` should support awaiting async function inside of a for loop.

e.g.
```js
for (let file of dir) {
  let content = await readFile(file);
}
```

The current `forOf` implementation doesn't expose the internal asynchronous scope, so there's no way to synchronize it.

```res
iter->Iterator.forOf(async file => {
  let content = await readFile(file)
})
// -> await?
```

Also the `AsyncIterator.forAwaitOf` should represent `for await (let el of x) { ... }`, not `for (let el of x) { await el }`